### PR TITLE
WIP - Fix #4 - Split days using local time instead of UTC time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <includes>
                         <include>**/*Spec.*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,18 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                        <include>**/*Test.*</include>
+                    </includes>
+                    <argLine>-Xmx4G -Xms1G</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.1.0</version>
 
@@ -81,6 +93,12 @@
             <groupId>net.iakovlev</groupId>
             <artifactId>timeshape</artifactId>
             <version>2018d.6</version>
+        </dependency>
+        <!-- Unit tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/edu/usf/cutr/tba/constants/TravelBehaviorConstants.java
+++ b/src/main/java/edu/usf/cutr/tba/constants/TravelBehaviorConstants.java
@@ -36,7 +36,7 @@ public class TravelBehaviorConstants {
     public static final long  WALKING_RUNNING_THRESHOLD = TimeUnit.MINUTES.toMillis(2);
 
     /**
-     * We split days at this number of milliseconds past midnight (e.g., if 3 hours, or 1.08e+7 milliseconds, then it will be split at 3am)
+     * We split days at this number of hours past midnight (e.g., if 3 hours, then it will be split at 3am)
      */
-    public static final long  SAME_DAY_TIME_DIFF = TimeUnit.HOURS.toMillis(3); // 3 hours
+    public static final long SAME_DAY_TIME_DIFF = 3; // 3 hours
 }

--- a/src/main/java/edu/usf/cutr/tba/constants/TravelBehaviorConstants.java
+++ b/src/main/java/edu/usf/cutr/tba/constants/TravelBehaviorConstants.java
@@ -35,5 +35,8 @@ public class TravelBehaviorConstants {
 
     public static final long  WALKING_RUNNING_THRESHOLD = TimeUnit.MINUTES.toMillis(2);
 
+    /**
+     * We split days at this number of milliseconds past midnight (e.g., if 3 hours, or 1.08e+7 milliseconds, then it will be split at 3am)
+     */
     public static final long  SAME_DAY_TIME_DIFF = TimeUnit.HOURS.toMillis(3); // 3 hours
 }

--- a/src/main/java/edu/usf/cutr/tba/manager/TravelBehaviorDataAnalysisManager.java
+++ b/src/main/java/edu/usf/cutr/tba/manager/TravelBehaviorDataAnalysisManager.java
@@ -283,13 +283,13 @@ public class TravelBehaviorDataAnalysisManager {
      */
     private void addTravelBehaviorRecord(TravelBehaviorRecord tbr) {
         // By default the day starts at 3 AM and ends at 3 AM next day
-        long sameDayDiff = ProgramOptions.getInstance().getSameDayStartPoint() == null ? TravelBehaviorConstants.
-                SAME_DAY_TIME_DIFF : TimeUnit.HOURS.toMillis(ProgramOptions.getInstance().getSameDayStartPoint());
+        long sameDayDiffHours = ProgramOptions.getInstance().getSameDayStartPoint() == null ? TravelBehaviorConstants.
+                SAME_DAY_TIME_DIFF : ProgramOptions.getInstance().getSameDayStartPoint();
 
         if (mOneDayTravelBehaviorRecordList.size() == 0) {
             // add new data to list with new tour id
             mOneDayTravelBehaviorRecordList.add(tbr);
-        } else if (TravelBehaviorUtils.isInSameDay(mOneDayTravelBehaviorRecordList, tbr, sameDayDiff)) {
+        } else if (TravelBehaviorUtils.isInSameDay(mOneDayTravelBehaviorRecordList, tbr, sameDayDiffHours)) {
             mOneDayTravelBehaviorRecordList.add(tbr);
         } else {
             applyTourAlgorithmToOneDayRecordList();

--- a/src/main/java/edu/usf/cutr/tba/manager/TravelBehaviorDataAnalysisManager.java
+++ b/src/main/java/edu/usf/cutr/tba/manager/TravelBehaviorDataAnalysisManager.java
@@ -282,10 +282,14 @@ public class TravelBehaviorDataAnalysisManager {
      * @param tbr TravelBehaviorRecord
      */
     private void addTravelBehaviorRecord(TravelBehaviorRecord tbr) {
+        // By default the day starts at 3 AM and ends at 3 AM next day
+        long sameDayDiff = ProgramOptions.getInstance().getSameDayStartPoint() == null ? TravelBehaviorConstants.
+                SAME_DAY_TIME_DIFF : TimeUnit.HOURS.toMillis(ProgramOptions.getInstance().getSameDayStartPoint());
+
         if (mOneDayTravelBehaviorRecordList.size() == 0) {
             // add new data to list with new tour id
             mOneDayTravelBehaviorRecordList.add(tbr);
-        } else if (TravelBehaviorUtils.isInSameDay(mOneDayTravelBehaviorRecordList, tbr)) {
+        } else if (TravelBehaviorUtils.isInSameDay(mOneDayTravelBehaviorRecordList, tbr, sameDayDiff)) {
             mOneDayTravelBehaviorRecordList.add(tbr);
         } else {
             applyTourAlgorithmToOneDayRecordList();

--- a/src/main/java/edu/usf/cutr/tba/utils/TravelBehaviorUtils.java
+++ b/src/main/java/edu/usf/cutr/tba/utils/TravelBehaviorUtils.java
@@ -18,7 +18,6 @@ package edu.usf.cutr.tba.utils;
 import edu.usf.cutr.tba.constants.TravelBehaviorConstants;
 import edu.usf.cutr.tba.model.TravelBehaviorInfo;
 import edu.usf.cutr.tba.model.TravelBehaviorRecord;
-import edu.usf.cutr.tba.options.ProgramOptions;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -95,8 +94,21 @@ public class TravelBehaviorUtils {
         return null;
     }
 
+    /**
+     * Returns true if the provided travel behavior record (tbr) is in the same day as the others in the provided list
+     * (oneDayTravelBehaviorRecordList), using (midnight + sameDayDiff) to split days.  Local time of the travel
+     * behavior data is used for midnight.
+     *
+     * @param oneDayTravelBehaviorRecordList
+     * @param tbr
+     * @param sameDayDiff                    the number of milliseconds past midnight to use as a time to split days.  For example, if you
+     *                                       use 1.08e+7, then 3am will be used to split the day.
+     * @return true if the provided travel behavior record (tbr) is in the same day as the others in the provided list
+     * (oneDayTravelBehaviorRecordList), using (midnight + sameDayDiff) to split days.  Local time of the travel
+     * behavior data is used for midnight.
+     */
     public static boolean isInSameDay(List<TravelBehaviorRecord> oneDayTravelBehaviorRecordList,
-                                      TravelBehaviorRecord tbr) {
+                                      TravelBehaviorRecord tbr, long sameDayDiff) {
         TravelBehaviorRecord lastRecord = oneDayTravelBehaviorRecordList.get(oneDayTravelBehaviorRecordList.size() - 1);
         Long lastRecordActivityEndTime = lastRecord.getActivityEndTimeMillis() != null ? lastRecord.getActivityEndTimeMillis() :
                 lastRecord.getLocationEndTimeMillis();
@@ -105,10 +117,6 @@ public class TravelBehaviorUtils {
                 tbr.getLocationEndTimeMillis();
 
         if (lastRecordActivityEndTime == null || newRecordActivityEndTime == null) return false;
-
-        // By default the day starts at 3 AM and ends at 3 AM next day
-        long sameDayDiff = ProgramOptions.getInstance().getSameDayStartPoint() == null ? TravelBehaviorConstants.
-                SAME_DAY_TIME_DIFF : TimeUnit.HOURS.toMillis(ProgramOptions.getInstance().getSameDayStartPoint());
 
         return TimeUnit.MILLISECONDS.toDays(lastRecordActivityEndTime - sameDayDiff) ==
                 TimeUnit.MILLISECONDS.toDays(newRecordActivityEndTime - sameDayDiff);

--- a/src/test/java/edu/usf/cutr/tba/test/TravelBehaviorUtilsTest.java
+++ b/src/test/java/edu/usf/cutr/tba/test/TravelBehaviorUtilsTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -21,17 +20,55 @@ public class TravelBehaviorUtilsTest {
     @Test
     public void testIsInSameDay() {
         List<TravelBehaviorRecord> list = new ArrayList<>();
+        // Use Eastern time location
+        double lat = 28.0587, lon = -82.4139;
 
         TravelBehaviorRecord day1a = new TravelBehaviorRecord(userId);
+        day1a.setStartLat(lat);
+        day1a.setStartLon(lon);
+        day1a.setEndLat(lat);
+        day1a.setEndLon(lon);
         TravelBehaviorRecord day1b = new TravelBehaviorRecord(userId);
+        day1b.setStartLat(lat);
+        day1b.setStartLon(lon);
+        day1b.setEndLat(lat);
+        day1b.setEndLon(lon);
         TravelBehaviorRecord day1c = new TravelBehaviorRecord(userId);
+        day1c.setStartLat(lat);
+        day1c.setStartLon(lon);
+        day1c.setEndLat(lat);
+        day1c.setEndLon(lon);
         TravelBehaviorRecord day1d = new TravelBehaviorRecord(userId);
+        day1d.setStartLat(lat);
+        day1d.setStartLon(lon);
+        day1d.setEndLat(lat);
+        day1d.setEndLon(lon);
         TravelBehaviorRecord day1e = new TravelBehaviorRecord(userId);
+        day1e.setStartLat(lat);
+        day1e.setStartLon(lon);
+        day1e.setEndLat(lat);
+        day1e.setEndLon(lon);
         TravelBehaviorRecord day1f = new TravelBehaviorRecord(userId);
+        day1f.setStartLat(lat);
+        day1f.setStartLon(lon);
+        day1f.setEndLat(lat);
+        day1f.setEndLon(lon);
         TravelBehaviorRecord day1g = new TravelBehaviorRecord(userId);
+        day1g.setStartLat(lat);
+        day1g.setStartLon(lon);
+        day1g.setEndLat(lat);
+        day1g.setEndLon(lon);
 
         TravelBehaviorRecord day2a = new TravelBehaviorRecord(userId);
+        day2a.setStartLat(lat);
+        day2a.setStartLon(lon);
+        day2a.setEndLat(lat);
+        day2a.setEndLon(lon);
         TravelBehaviorRecord day2b = new TravelBehaviorRecord(userId);
+        day2b.setStartLat(lat);
+        day2b.setStartLon(lon);
+        day2b.setEndLat(lat);
+        day2b.setEndLon(lon);
 
         // Day 1
 
@@ -74,7 +111,7 @@ public class TravelBehaviorUtilsTest {
         day2b.setActivityEndTimeMillis(1565494582198L);
 
         // Days are split at midnight + SAME_DAY_TIME_DIFF, using local time.  We use 3am local time to split days in the below tests.
-        final long SAME_DAY_TIME_DIFF = TimeUnit.HOURS.toMillis(3);
+        final long SAME_DAY_TIME_DIFF = 3;
 
         // Add the times in the same day one-by-one and confirm that they all belong in the same day (returns true)
         list.add(day1a);
@@ -94,6 +131,7 @@ public class TravelBehaviorUtilsTest {
 
         list.add(day1f);
         assertTrue(TravelBehaviorUtils.isInSameDay(list, day1g, SAME_DAY_TIME_DIFF));
+        list.add(day1g);
 
         // Test the times in day two against the day 1 list, and confirm that they all return false (not in the same day)
         assertFalse(TravelBehaviorUtils.isInSameDay(list, day2a, SAME_DAY_TIME_DIFF));

--- a/src/test/java/edu/usf/cutr/tba/test/TravelBehaviorUtilsTest.java
+++ b/src/test/java/edu/usf/cutr/tba/test/TravelBehaviorUtilsTest.java
@@ -1,0 +1,102 @@
+package edu.usf.cutr.tba.test;
+
+import edu.usf.cutr.tba.model.TravelBehaviorRecord;
+import edu.usf.cutr.tba.utils.TravelBehaviorUtils;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests utilities for processing travel behavior data
+ */
+public class TravelBehaviorUtilsTest {
+
+    final String userId = "test-user";
+
+    @Test
+    public void testIsInSameDay() {
+        List<TravelBehaviorRecord> list = new ArrayList<>();
+
+        TravelBehaviorRecord day1a = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1b = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1c = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1d = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1e = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1f = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day1g = new TravelBehaviorRecord(userId);
+
+        TravelBehaviorRecord day2a = new TravelBehaviorRecord(userId);
+        TravelBehaviorRecord day2b = new TravelBehaviorRecord(userId);
+
+        // Day 1
+
+        // Local time: Friday, August 9, 2019 4:29:42.198 PM
+        // UTC time: Friday, August 9, 2019 8:29:42.198 PM
+        day1a.setActivityEndTimeMillis(1565382582198L);
+
+        // Local time: Friday, August 9, 2019 7:49:42.198 PM
+        // UTC time: Friday, August 9, 2019 11:49:42.198 PM
+        day1b.setActivityEndTimeMillis(1565394582198L);
+
+        // Local time: Friday, August 9, 2019 8:39:42.198 PM
+        // UTC time: Saturday, August 10, 2019 12:39:42.198 AM
+        day1c.setActivityEndTimeMillis(1565397582198L);
+
+        // Local time: Friday, August 9, 2019 10:43:02.198 PM
+        // UTC time: Saturday, August 10, 2019 2:43:02.198 AM
+        day1d.setActivityEndTimeMillis(1565404982198L);
+
+        // Local time: Friday, August 9, 2019 11:33:02.198 PM
+        // UTC time: Saturday, August 10, 2019 3:33:02.198 AM
+        day1e.setActivityEndTimeMillis(1565407982198L);
+
+        // Local time: Saturday, August 10, 2019 12:06:22.198 AM
+        // UTC time: Saturday, August 10, 2019 4:06:22.198 AM
+        day1f.setActivityEndTimeMillis(1565409982198L);
+
+        // Local time:  Saturday, August 10, 2019 2:53:02.198 AM
+        // UTC time: Saturday, August 10, 2019 6:53:02.198 AM
+        day1g.setActivityEndTimeMillis(1565419982198L);
+
+        // Day 2
+
+        // Local time:  Saturday, August 10, 2019 3:09:52.198 AM
+        // UTC time: Saturday, August 10, 2019 7:09:52.198 AM
+        day2a.setActivityEndTimeMillis(1565420992198L);
+
+        // Local time: Saturday, August 10, 2019 11:36:22.198 PM
+        // UTC time: Sunday, August 11, 2019 3:36:22.198 AM
+        day2b.setActivityEndTimeMillis(1565494582198L);
+
+        // Days are split at midnight + SAME_DAY_TIME_DIFF, using local time.  We use 3am local time to split days in the below tests.
+        final long SAME_DAY_TIME_DIFF = TimeUnit.HOURS.toMillis(3);
+
+        // Add the times in the same day one-by-one and confirm that they all belong in the same day (returns true)
+        list.add(day1a);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1b, SAME_DAY_TIME_DIFF));
+
+        list.add(day1b);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1c, SAME_DAY_TIME_DIFF));
+
+        list.add(day1c);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1d, SAME_DAY_TIME_DIFF));
+
+        list.add(day1d);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1e, SAME_DAY_TIME_DIFF));
+
+        list.add(day1e);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1f, SAME_DAY_TIME_DIFF));
+
+        list.add(day1f);
+        assertTrue(TravelBehaviorUtils.isInSameDay(list, day1g, SAME_DAY_TIME_DIFF));
+
+        // Test the times in day two against the day 1 list, and confirm that they all return false (not in the same day)
+        assertFalse(TravelBehaviorUtils.isInSameDay(list, day2a, SAME_DAY_TIME_DIFF));
+        assertFalse(TravelBehaviorUtils.isInSameDay(list, day2b, SAME_DAY_TIME_DIFF));
+    }
+}


### PR DESCRIPTION
*WIP - Please do not merge*

I added tests to evaluate #4.

Right now the tests fail with the below message, confirming that splits are happening at 3am UTC, not 3am local time.

~~~
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.089 s <<< FAILURE! - in edu.usf.cutr.tba.test.TravelBehaviorUtilsTest
[ERROR] testIsInSameDay(edu.usf.cutr.tba.test.TravelBehaviorUtilsTest)  Time elapsed: 0.013 s  <<< FAILURE!
java.lang.AssertionError
        at edu.usf.cutr.tba.test.TravelBehaviorUtilsTest.testIsInSameDay(TravelBehaviorUtilsTest.java:90)
~~~